### PR TITLE
Updated Mat Ryer's blueprints book to 2nd ed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,11 @@ This book helps Javascripters become Gophers. Outlining the differences between 
 
 Go in Action introduces the Go language, guiding you from inquisitive developer to Go guru. The book begins by introducing the unique features and concepts of Go. (We assume you're up to speed with another programming language already, so don't expect to spend a lot of time rehearsing stuff you already know.) Then, you'll get hands-on experience writing real-world applications including web sites and network servers, as well as techniques to manipulate and convert data at speeds that will make your friends jealous. In the final chapters, you'll go in-depth with the language and see the tricks and secrets that the Go masters are using to make their applications perform. For example, you'll learn to use Go's powerful reflection libraries and work with real-world examples of integration with C code.
 
-###[Go Programming Blueprints](https://www.packtpub.com/application-development/go-programming-blueprints)
+###[Go Programming Blueprints - 2nd Ed.](https://www.packtpub.com/application-development/go-programming-blueprints-second-edition)
 
-<img src="http://akamaicovers.oreilly.com/images/9781783988020/lrg.jpg" width="120px"/>
+<img src="https://dz13w8afd47il.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/8949cov_.jpg" width="120px"/>
 
-Build real-world, production-ready solutions in Go using cutting-edge technology and techniques.
-
-Intended for seasoned Go programmers who want to put their expertise in Go to use to solve big, real-world, modern problems. With a basic understanding of channels and goroutines, you will hone your skills to build tools and programs that are quick and simple. You need not be an expert in distributed systems or technologies in order to deliver solutions capable of great scale. It is assumed that you are familiar with the basic concepts of Go.
+This book shows you how to build powerful systems and drops you into real-world situations. Scale, performance, and high availability lie at the heart of our projects, and the lessons learned throughout this book will arm you with everything you need to build world-class solutions. 
 
 ###[Programming in Go: Creating Applications for the 21st Century](http://www.informit.com/store/programming-in-go-creating-applications-for-the-21st-9780321774637)
 


### PR DESCRIPTION
Takes care of issue #43.

I took the description from the new book, dropping the overly marketing-ish verbiage ("Each project could form the basis of a start-up, which means they are directly applicable to modern software markets." -- really?)

Updated the link and the book cover image.