### PR TITLE
Fix h3 headers in Markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Add books with this format :
 
 
 ```
-###[BOOK NAME](BOOK URL) 
+### [BOOK NAME](BOOK URL)
 
 <img src="BOOK COVER IMAGE ADDRESS" width="120px"/>
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Go Books [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed7
 **Starter Books**
 ----
 
-###[The Little Go Book](http://openmymind.net/The-Little-Go-Book/) *Free*
+### [The Little Go Book](http://openmymind.net/The-Little-Go-Book/) *Free*
 
 <img src="http://openmymind.net/assets/go/title.png" width="120px"/>
 
 The Little Go Book is a free introduction to Google's Go programming language. It's aimed at developers who might not be quite comfortable with the idea of pointers and static typing. It's longer than the other Little books, but hopefully still captures that little feeling.
 
-###[An Introduction to Programming in Go](http://www.golang-book.com/) *Free*
+### [An Introduction to Programming in Go](http://www.golang-book.com/) *Free*
 
 <img src="http://www.golang-book.com/public/img/intro/cover.0.png" width="120px"/>
 
@@ -27,44 +27,44 @@ This book is a short, concise introduction to computer programming using the lan
 
 This book is free to [read online](http://www.golang-book.com/) or [pdf form](http://www.golang-book.com/public/pdf/gobook.pdf).
 
-###[Go Bootcamp](http://www.golangbootcamp.com/) *Free*
+### [Go Bootcamp](http://www.golangbootcamp.com/) *Free*
 
 <img src="https://softcover.s3.amazonaws.com/38/GoBootcamp/images/cover-web.png" width="120px"/>
 
 This companion book contains material initially written specifically for this event as well as content from Google & the Go team under Creative Commons Attribution 3.0 License and code licensed under a BSD license.
 
-###[Learning Go](http://www.miek.nl/go) *Free*
+### [Learning Go](http://www.miek.nl/go) *Free*
 
 A online book to start learning Golang. It features numerous exercises (and answers).
 
 The [markdown source is available on Github](https://github.com/miekg/learninggo).
 
-###[Go for Javascript Developers](https://github.com/bulim/go-for-javascript-developers) *Free*
+### [Go for Javascript Developers](https://github.com/bulim/go-for-javascript-developers) *Free*
 
 <img src="https://raw.githubusercontent.com/bulim/go-for-javascript-developers/master/images/thumb.png" width="120px"/>
 
 This book helps Javascripters become Gophers. Outlining the differences between these languages makes it easier to switch back and forth, and can help mitigate potential issues when doing so.
 
-###[Go in Action](https://www.manning.com/books/go-in-action)
+### [Go in Action](https://www.manning.com/books/go-in-action)
 
 <img src="https://images.manning.com/120/160/resize/book/c/4037d5d-e5e5-49bf-a3c1-480be2907eaa/Kennedy-GO-HI.png" width="120px">
 
 Go in Action introduces the Go language, guiding you from inquisitive developer to Go guru. The book begins by introducing the unique features and concepts of Go. (We assume you're up to speed with another programming language already, so don't expect to spend a lot of time rehearsing stuff you already know.) Then, you'll get hands-on experience writing real-world applications including web sites and network servers, as well as techniques to manipulate and convert data at speeds that will make your friends jealous. In the final chapters, you'll go in-depth with the language and see the tricks and secrets that the Go masters are using to make their applications perform. For example, you'll learn to use Go's powerful reflection libraries and work with real-world examples of integration with C code.
 
-###[Go Programming Blueprints - 2nd Ed.](https://www.packtpub.com/application-development/go-programming-blueprints-second-edition)
+### [Go Programming Blueprints - 2nd Ed.](https://www.packtpub.com/application-development/go-programming-blueprints-second-edition)
 
 <img src="https://dz13w8afd47il.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/8949cov_.jpg" width="120px"/>
 
 This book shows you how to build powerful systems and drops you into real-world situations. Scale, performance, and high availability lie at the heart of our projects, and the lessons learned throughout this book will arm you with everything you need to build world-class solutions.
 
-###[Programming in Go: Creating Applications for the 21st Century](http://www.informit.com/store/programming-in-go-creating-applications-for-the-21st-9780321774637)
+### [Programming in Go: Creating Applications for the 21st Century](http://www.informit.com/store/programming-in-go-creating-applications-for-the-21st-9780321774637)
 
 <img src="http://www.informit.com/ShowCover.aspx?isbn=9780321774637&type=f" width="120px"/>
 
  Programming in Go brings together all the knowledge you need to evaluate Go, think in Go, and write high-performance software with Go. Summerfield presents multiple idiom comparisons showing exactly how Go improves upon older languages, calling special attention to Go’s key innovations. Along the way, he explains everything from the absolute basics through Go’s lock-free channel-based concurrency and its flexible and unusual duck-typing type-safe approach to object-orientation.
 
 
-###[The Go Programming Language](http://gopl.io/)
+### [The Go Programming Language](http://gopl.io/)
 
 <a href='http://gopl.io/'><img src="http://gopl.io/cover.png" width="120px"/></a>
 
@@ -116,35 +116,35 @@ Solve your Go problems using a problem-solution approach. Each recipe is a self-
 **Advanced Books**
 ---
 
-###[Test-driven development with Go ](https://leanpub.com/golang-tdd) *Free*
+### [Test-driven development with Go ](https://leanpub.com/golang-tdd) *Free*
 
 A short guide to Test-driven development in golang. free to [read online](https://leanpub.com/golang-tdd/read).
 
-###[Network Programming with Go](https://www.gitbook.com/book/jannewmarch/network-programming-with-go-golang-/details) *Free*
+### [Network Programming with Go](https://www.gitbook.com/book/jannewmarch/network-programming-with-go-golang-/details) *Free*
 
 <img src="https://ek8whxe.cloudimg.io/s/width/226/https://www.gitbook.com/cover/book/jannewmarch/network-programming-with-go-golang-.jpg" width="120px"/>
 
 An e-book on building network applications using the Google Go programming language. Free to [read online](https://www.gitbook.com/book/jannewmarch/network-programming-with-go-golang-/details).
 
-###[Mastering Concurrency in Go](http://shop.oreilly.com/product/9781783983483.do)
+### [Mastering Concurrency in Go](http://shop.oreilly.com/product/9781783983483.do)
 
 <img src="http://akamaicovers.oreilly.com/images/9781783983483/lrg.jpg" width="120px"/>
 
 This book will take you through the history of concurrency, how Go utilizes it, how Go differs from other languages, and the features and structures of Go's concurrency core. Each step of the way, the book will present real, usable examples with detailed descriptions of the methodologies used. By the end, you will feel comfortable designing a safe, data-consistent, high-performance concurrent application in Go.
 
-###[Go in Practice](http://www.manning.com/butcher/)
+### [Go in Practice](http://www.manning.com/butcher/)
 
 <img src="http://www.manning.com/butcher/butcher_cover150.jpg" width="120px"/>
 
 Go in Practice guides you through dozens of real-world techniques in key areas like package management, microservice communication, and more. Following a cookbook-style Problem/Solution/Discussion format, this practical handbook builds on the foundational concepts of the Go language and introduces specific strategies you can use in your day-to-day applications. You'll learn techniques for building web services, using Go in the cloud, testing and debugging, routing, network applications, and much more.
 
-###[A Go Developer's Notebook](https://leanpub.com/GoNotebook/)
+### [A Go Developer's Notebook](https://leanpub.com/GoNotebook/)
 
 <img src="https://s3.amazonaws.com/titlepages.leanpub.com/GoNotebook/large?1425551366"  width="120px"/>
 
 A developer's exprience in golang.
 
-###[The Go Programming Language Phrasebook](http://www.informit.com/store/go-programming-language-phrasebook-9780321817143)
+### [The Go Programming Language Phrasebook](http://www.informit.com/store/go-programming-language-phrasebook-9780321817143)
 
 <img src="http://www.informit.com/ShowCover.aspx?isbn=9780321817143&type=f"  width="120px"/>
 
@@ -153,25 +153,25 @@ Tested, easy-to-adapt code examples illuminate every step of Go development, hel
 
 **Web Development**
 ----
-###[Building Web Apps with Go](https://www.gitbook.com/book/codegangsta/building-web-apps-with-go/details) *Free*
+### [Building Web Apps with Go](https://www.gitbook.com/book/codegangsta/building-web-apps-with-go/details) *Free*
 
 <img src="https://www.gitbook.com/cover/book/codegangsta/building-web-apps-with-go.jpg" width="120px"/>
 
 A good resource for start Building Web Apps with Go. Free to [read online](http://codegangsta.gitbooks.io/building-web-apps-with-go/content/), [pdf](https://www.gitbook.com/book/codegangsta/building-web-apps-with-go/details) and [mobi](https://www.gitbook.com/book/codegangsta/building-web-apps-with-go/details) version.
 
-###[Build Web Application with Golang](https://www.gitbook.com/book/astaxie/build-web-application-with-golang/details) *Free*
+### [Build Web Application with Golang](https://www.gitbook.com/book/astaxie/build-web-application-with-golang/details) *Free*
 
 <img src="https://www.gitbook.com/cover/book/astaxie/build-web-application-with-golang.jpg" width="120px"/>
 
 Another awesome book for learning Web Development in Golang. Free to [read online](http://astaxie.gitbooks.io/build-web-application-with-golang/content/en/index.html)
 
-###[Mastering Go Web Services ](http://shop.oreilly.com/product/9781783981304.do)
+### [Mastering Go Web Services ](http://shop.oreilly.com/product/9781783981304.do)
 
 <img src="http://akamaicovers.oreilly.com/images/9781783981304/lrg.jpg" width="120px"/>
 
 This book will take you through the most important aspects of designing, building, and deploying a web service utilizing idiomatic REST practices with a focus on speed, security, and flexibility. You will begin by building your first API in Go using the HTTP package. You will look at designing and building your application including popular design structures like Model-View-Controller. You will also understand methods for deploying code to staging and development. Finally, you will see how the security features in Go can be used for protection against SQL injection, and sensitive data compromise.
 
-###[Level Up Your Web Apps With Go](https://learnable.com/books/level-up-your-web-apps-with-go)
+### [Level Up Your Web Apps With Go](https://learnable.com/books/level-up-your-web-apps-with-go)
 
 <img src="http://akamaicovers.oreilly.com/images/9780992461294/lrg.jpg" width="120px"/>
 
@@ -179,31 +179,31 @@ This book gives you all you need to use Go in your web applications. You’ll le
 
 At each step, you’ll get advice for better coding in Go. You’ll see how to structure projects, how to use concurrency effectively, and best practices for testing—as well as many other hints and tips gleaned from real world experience of developing web applications with Go.
 
-###[Go Web Programming](http://www.manning.com/chang/)
+### [Go Web Programming](http://www.manning.com/chang/)
 
 <img src="http://www.manning.com/chang/chang_cover150.jpg" width="120px"/>
 
 Go Web Programming teaches you how to build web applications in Go using modern design principles. You'll work through numerous examples that introduce core concepts like processing requests and sending responses, template engines, and data persistence. You'll also dive into more advanced topics, such as concurrency, web application testing and deployment both to barebones servers and PaaS providers.
 
-###[Webapps in Go the anti textbook](https://github.com/thewhitetulip/web-dev-golang-anti-textbook) *free*
+### [Webapps in Go the anti textbook](https://github.com/thewhitetulip/web-dev-golang-anti-textbook) *free*
 
 <img src="https://github.com/thewhitetulip/web-dev-golang-anti-textbook/raw/master/cover.jpg" width="120px"/>
 
 This book was written to teach how to develop web applications in Go for people who know a bit of Go and have basic information about web applications in general. We (you) will build a webapp without using a third party framework and using as few external libraries as possible. The advantage is that you'll learn a lot when you code without a framework.
 
-###[Cloud Native Go: Building Web Applications and Microservices for the Cloud with Go and React](https://www.amazon.com/Cloud-Native-Applications-Microservices-Developers/dp/0672337797)
+### [Cloud Native Go: Building Web Applications and Microservices for the Cloud with Go and React](https://www.amazon.com/Cloud-Native-Applications-Microservices-Developers/dp/0672337797)
 
 <a href="https://www.amazon.com/Cloud-Native-Applications-Microservices-Developers/dp/0672337797"><img src="https://images-na.ssl-images-amazon.com/images/I/51oy5Nd9BoL._SX384_BO1,204,203,200_.jpg" width="120px"/></a>
 
 Today, companies and developers need to respond to changing markets at breakneck speeds. Organizations that aren't built on highly-available, rapidly-evolving software are going the way of the dinosaurs. Cloud Native Go brings together the knowledge developers need to build massive-scale cloud applications that meet the insatiable demands of today's customers and markets.
 
-###[Web Development with Go: Learn to Create Real World Web Applications using Go](https://gumroad.com/l/web-development-with-go)
+### [Web Development with Go: Learn to Create Real World Web Applications using Go](https://gumroad.com/l/web-development-with-go)
 
 <a href="https://gum.co/web-development-with-go"><img src="http://www.calhoun.io/static/Cover300ppi.png" width="120px"/></a>
 
 Web Development with Go was written to teach both beginners and experts how to create and deploy a real web application. You won't be building a boilerplate TODO list, but will instead be creating and deploying a production ready photo gallery application, similar to Pixieset, from scratch. The book assumes no previous web development experience and covers everything you need to know to successfully build your own web application.
 
-###[Go: Building Web Applications](https://amzn.com/B01LD8K5C0)
+### [Go: Building Web Applications](https://amzn.com/B01LD8K5C0)
 
 <a href="https://amzn.com/B01LD8K5C0"><img src="https://images-na.ssl-images-amazon.com/images/I/51vKBWRztbL.jpg" width="120px"/></a>
 
@@ -212,11 +212,11 @@ This course is an invaluable resource to help you understand Go's powerful featu
 Resources
 ====
 
-###[A tour of Go](https://tour.golang.org/)
-###[Video: Learn Go Syntax in one video](http://www.youtube.com/watch?v=CF9S4QZuV30)
-###[Tutorials: Go by Example](https://gobyexample.com/)
-###[Go Fundamentals Video Training](http://shop.oreilly.com/category/learning-path/go-fundamentals.do)
-###[More Books on the Go Wiki](https://github.com/golang/go/wiki/Books)
+### [A tour of Go](https://tour.golang.org/)
+### [Video: Learn Go Syntax in one video](http://www.youtube.com/watch?v=CF9S4QZuV30)
+### [Tutorials: Go by Example](https://gobyexample.com/)
+### [Go Fundamentals Video Training](http://shop.oreilly.com/category/learning-path/go-fundamentals.do)
+### [More Books on the Go Wiki](https://github.com/golang/go/wiki/Books)
 
 Contributing
 ====


### PR DESCRIPTION
GitHub.com and mobile apps don't render `###text` correctly. It has to be `### text` (space).