### PR TITLE
Add API Foundations and 12FA with Go books

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ In Black Hat Go, you'll learn how to write powerful and effective penetration te
 
 The main goal of this book is to help developers avoid common mistakes while at the same time, learning a new programming language through a "hands-on approach". This book provides a good level of detail on "how to do it securely" showing what kind of security problems could arise during development.
 
+### [Concurrency in Go](http://shop.oreilly.com/product/0636920046189.do)
+
+[<img src="https://covers.oreillystatic.com/images/0636920046189/cat.gif" width="120px"/>](http://shop.oreilly.com/product/0636920046189.do)
+
+Concurrency can be notoriously difficult to get right, but fortunately, the Go open source programming language makes working with concurrency tractable and even easy. If you’re a developer familiar with Go, this practical book demonstrates best practices and patterns to help you incorporate concurrency into your systems.
+
 
 **Web Development**
 ----

--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ Learn idiomatic, efficient, clean, and extensible Go design and concurrency patt
 
 Build concurrent, easy-to-maintain responsive applications in Go.
 
+### [Black Hat Go](https://www.nostarch.com/blackhatgo)
+
+[<img src="https://www.nostarch.com/sites/default/files/styles/uc_product_full/public/bhg_cover-front.png" width="120px"/>](https://www.nostarch.com/blackhatgo)
+
+In Black Hat Go, you'll learn how to write powerful and effective penetration testing tools in Go, a language revered for its speed and scalability. Start off with an introduction to Go fundamentals like data types, control structures, and error handling; then, dive into the deep end of Go’s offensive capabilities.
+
+### [Go programming language secure coding practices guide](https://checkmarx.gitbooks.io/go-scp/) *Free*
+
+The main goal of this book is to help developers avoid common mistakes while at the same time, learning a new programming language through a "hands-on approach". This book provides a good level of detail on "how to do it securely" showing what kind of security problems could arise during development.
+
+
 **Web Development**
 ----
 ### [Building Web Apps with Go](https://www.gitbook.com/book/codegangsta/building-web-apps-with-go/details) *Free*

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Solve your Go problems using a problem-solution approach. Each recipe is a self-
 
 *Learning Go Programming* is a book intended to help new, and seasoned programmers alike, to get into the Go programming language. The book distills the language specs, the documentations, the blogs, the videos, slides, and the author's experiences of writing Go into content that carefully provides the right amount of depth and insights to help you understand the language and its design.
 
+### [API Foundations in Go](https://leanpub.com/api-foundations)
+
+<a href="https://leanpub.com/api-foundations"><img src="https://s3.amazonaws.com/titlepages.leanpub.com/api-foundations/hero?1504290765" width="120px"/></a>
+
+With this book you'll learn to use Go, taking advantage of it's multi-threaded nature, and typed syntax. Starting your API implementation in Go is your first step towards what a rock solid API should be.
+
 **Advanced Books**
 ---
 
@@ -221,6 +227,12 @@ Web Development with Go was written to teach both beginners and experts how to c
 <a href="https://amzn.com/B01LD8K5C0"><img src="https://images-na.ssl-images-amazon.com/images/I/51vKBWRztbL.jpg" width="120px"/></a>
 
 This course is an invaluable resource to help you understand Go's powerful features to build simple, reliable, secure, and efficient web applications.
+
+### [12 Factor Applications with Docker and Go](https://leanpub.com/12fa-docker-golang)
+
+<a href="https://leanpub.com/12fa-docker-golang"><img src="https://s3.amazonaws.com/titlepages.leanpub.com/12fa-docker-golang/hero?1503844662" width="120px"/></a>
+
+A book filled with examples on how to use Docker and Go to create the ultimate 12 Factor applications. It goes over individual steps of [The Twelve-Factor App](12factor.net) guidelines and how to implement them with Go and Docker.
 
 Resources
 ====

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Go in Action introduces the Go language, guiding you from inquisitive developer 
 
 ### [Go Programming Blueprints - 2nd Ed.](https://www.packtpub.com/application-development/go-programming-blueprints-second-edition)
 
-<img src="https://dz13w8afd47il.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/8949cov_.jpg" width="120px"/>
+<img src="https://www.packtpub.com/sites/default/files/8949cov_.png" width="120px"/>
 
 This book shows you how to build powerful systems and drops you into real-world situations. Scale, performance, and high availability lie at the heart of our projects, and the lessons learned throughout this book will arm you with everything you need to build world-class solutions.
 
@@ -160,7 +160,7 @@ Tested, easy-to-adapt code examples illuminate every step of Go development, hel
 
 ### [Go Design Patterns](https://www.packtpub.com/application-development/go-design-patterns)
  
-<img src="https://dz13w8afd47il.cloudfront.net/sites/default/files/imagecache/ppv4_main_book_cover/image.jpg" width="120px"/>
+<img src="https://www.packtpub.com/sites/default/files/B05557.png" width="120px"/>
 
 Learn idiomatic, efficient, clean, and extensible Go design and concurrency patterns by using TDD.
 


### PR DESCRIPTION
I added:

* API Foundations in Go
* 12 Factor Applications with Docker and Go
* Concurrency in Go
* Black hat Go
* Secure coding practices guide

I also fixed the images for some packpub books which were 404'd in Travis. This closes #46.